### PR TITLE
Trivial example of transform of html to markdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ bazel-*
 *.war
 .idea
 *.iml
+.DS_Store
+out/

--- a/BUILD
+++ b/BUILD
@@ -2,6 +2,7 @@ load("@rules_intellij_generate//:def.bzl", "intellij_modules_xml")
 intellij_modules_xml(
     name = "modules_xml",
     deps = [
+        "//convert:iml",
         "//service:iml",
     ]
 )

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ curl https://your-appengine-service-id.appspot.com/foo
 {'requested' : '/foo'}
 ```
 
+## Scenario GDocs
+
+See [this gdrive folder](https://drive.google.com/drive/folders/1SyDE0Ult3-PTh-dHAfOOkr7pikkKmASW).
+
 ## Project conventions
 
 ### Git

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,20 +8,22 @@ load("@io_bazel_rules_appengine//appengine:appengine.bzl", "appengine_repositori
 appengine_repositories()
 
 
+rig_sha="c0dcaa85aeb0e266fb531e84018efdf173d4be17"
+
 # This should be nailed to a particular sha and have a sha256 specified before release.
 # (It's just that things are changing quickly right now)
 http_archive(
     name = "rules_intellij_generate",
-    url = "https://github.com/sconover/rules_intellij_generate/archive/5e9d9c0b82356c962cc385da3c2dcad7c24ccba4.tar.gz",
-    strip_prefix = "rules_intellij_generate-5e9d9c0b82356c962cc385da3c2dcad7c24ccba4/rules",
+    url = "https://github.com/sconover/rules_intellij_generate/archive/%s.tar.gz" % rig_sha,
+    strip_prefix = "rules_intellij_generate-%s/rules" % rig_sha,
 )
 load("@rules_intellij_generate//:def.bzl", "repositories_for_intellij_generate")
 repositories_for_intellij_generate()
 
 http_archive(
     name = "rules_junit5",
-    url = "https://github.com/sconover/rules_intellij_generate/archive/5e9d9c0b82356c962cc385da3c2dcad7c24ccba4.tar.gz",
-    strip_prefix = "rules_intellij_generate-5e9d9c0b82356c962cc385da3c2dcad7c24ccba4/rules_junit5",
+    url = "https://github.com/sconover/rules_intellij_generate/archive/%s.tar.gz" % rig_sha,
+    strip_prefix = "rules_intellij_generate-%s/rules_junit5" % rig_sha,
 )
 load("@rules_junit5//:def.bzl", "junit5_repositories")
 junit5_repositories()

--- a/convert/BUILD
+++ b/convert/BUILD
@@ -1,0 +1,32 @@
+package(default_visibility = ["//:__subpackages__"])
+
+load("@rules_intellij_generate//:def.bzl",
+    "intellij_source_java_library")
+
+intellij_source_java_library(
+    name="lib",
+    source_folder_to_wildcard_map={"javasrc":"**/*.java"},
+)
+
+load("@rules_junit5//:def.bzl", "JUNIT5_MINIMAL_DEPS")
+intellij_source_java_library(
+    name="test_lib",
+    source_folder_to_wildcard_map={"javatest":"**/*.java"},
+    deps=[
+        ":lib",
+    ] + JUNIT5_MINIMAL_DEPS,
+)
+
+load("@rules_intellij_generate//:def.bzl", "intellij_iml")
+intellij_iml(
+    name = "iml",
+    java_source=":lib",
+    test_java_source=":test_lib",
+)
+
+load("@rules_junit5//:def.bzl", "junit5_all_in_package_test")
+junit5_all_in_package_test(
+    name="tests",
+    java_package="gdocmd",
+    runtime_deps=[":test_lib"]
+)

--- a/convert/javasrc/gdocmd/convert/Converter.java
+++ b/convert/javasrc/gdocmd/convert/Converter.java
@@ -1,0 +1,40 @@
+package gdocmd.convert;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static gdocmd.convert.Util.checkState;
+import static gdocmd.convert.Util.joinStringList;
+import static gdocmd.convert.Util.xpathList;
+import static java.lang.String.format;
+
+class Converter {
+
+  private static final String HTML_FILE_SUFFIX = ".html";
+  private static final String MD_FILE_SUFFIX = ".md";
+  private static final String META_LINE = "<meta content=\"text/html; charset=UTF-8\" http-equiv=\"content-type\">";
+
+  public static Map<String, String> convert(Map<String, String> gdocHtmlZipPathToContent) {
+    checkState(!gdocHtmlZipPathToContent.isEmpty(), "empty gdoc content");
+
+    Map.Entry<String, String> pathAndHtml = gdocHtmlZipPathToContent.entrySet().iterator().next();
+    String htmlPath = pathAndHtml.getKey();
+    checkState(htmlPath.endsWith(HTML_FILE_SUFFIX), format("expected '%s' to end in .html", htmlPath));
+
+    String pathWithoutHtml = htmlPath.substring(0, htmlPath.length()-HTML_FILE_SUFFIX.length());
+    String mdPath = pathWithoutHtml + MD_FILE_SUFFIX;
+
+    String htmlContent = pathAndHtml.getValue();
+    checkState(!htmlContent.isEmpty(), format("html should not be empty, path='%s'", htmlPath));
+
+    // it's not well-formed from an xml perspective.
+    // if this is the only case of non-well-form-ed-ness, we're good
+    htmlContent = htmlContent.replace(META_LINE, "");
+
+    String mdContent = joinStringList("\n", xpathList(htmlContent, "//*[@class='c2']"));
+
+    Map<String, String> mdPathToContent = new LinkedHashMap<>();
+    mdPathToContent.put(mdPath, mdContent);
+    return mdPathToContent;
+  }
+}

--- a/convert/javasrc/gdocmd/convert/Util.java
+++ b/convert/javasrc/gdocmd/convert/Util.java
@@ -1,0 +1,110 @@
+package gdocmd.convert;
+
+import org.w3c.dom.NodeList;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringJoiner;
+
+import static java.lang.String.format;
+
+public class Util {
+  public static String readFile(String path) {
+    checkState(path != null, "expected file path to not be null");
+    Path fsPath = FileSystems.getDefault().getPath(path);
+    checkState(fsPath.toFile().exists(), format("expected file to exist: '%s'", path));
+    try {
+      return new String(Files.readAllBytes(fsPath));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static void checkState(boolean ok, String failureMessage) {
+    if (!ok) {
+      throw new IllegalStateException(failureMessage);
+    }
+  }
+
+  public static List<String> xpathList(String xmlDocument, String xpath) {
+    NodeList nodeList = xpathNodeListFromDoc(xpath, parseXml(xmlDocument));
+    List<String> results = new ArrayList<>();
+    for (int i = 0; i < nodeList.getLength(); i++) {
+      results.add(nodeList.item(i).getTextContent());
+    }
+    return results;
+  }
+
+  public static String xpath(String xmlDocument, String xpath) {
+    NodeList nodeList = xpathNodeListFromDoc(xpath, parseXml(xmlDocument));
+
+    if (nodeList.getLength() != 1) {
+      throw new RuntimeException(format("expected number of results for xpath text result query to be exactly 1, " +
+        "but was %d, results: %s", nodeList.getLength(), nodeList));
+    }
+    return nodeList.item(0).getTextContent();
+  }
+
+  private static NodeList xpathNodeListFromDoc(String xpathExpression, Document doc) {
+    try {
+      XPathFactory xPathfactory = XPathFactory.newInstance();
+      XPath xpath = xPathfactory.newXPath();
+      XPathExpression expr = xpath.compile(xpathExpression);
+      return (NodeList) expr.evaluate(doc, XPathConstants.NODESET);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+
+  private static Document parseXml(String xmlString) {
+    try {
+      DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+      factory.setIgnoringElementContentWhitespace(true);
+      DocumentBuilder builder = factory.newDocumentBuilder();
+      builder.setErrorHandler(new ErrorHandler() {
+        @Override
+        public void warning(SAXParseException exception) throws SAXException {
+          // silence SAX parse warnings
+        }
+
+        @Override
+        public void error(SAXParseException exception) throws SAXException {
+          // silence SAX parse errors
+        }
+
+        @Override
+        public void fatalError(SAXParseException exception) throws SAXException {
+          throw exception;
+        }
+      });
+      return builder.parse(new ByteArrayInputStream(xmlString.getBytes()));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static String joinStringList(String joinWith, List<String> stringsToJoin) {
+    StringJoiner stringJoiner = new StringJoiner(joinWith);
+    stringsToJoin.forEach(s -> stringJoiner.add(s));
+    return stringJoiner.toString();
+  }
+}

--- a/convert/javatest/gdocmd/convert/ScenariosTest.java
+++ b/convert/javatest/gdocmd/convert/ScenariosTest.java
@@ -1,0 +1,21 @@
+package gdocmd.convert;
+
+import org.junit.jupiter.api.Test;
+
+import static gdocmd.convert.Converter.convert;
+import static gdocmd.convert.TestUtil.mapOf;
+import static gdocmd.convert.Util.readFile;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ScenariosTest {
+  @Test
+  public void trivial01() {
+    assertEquals(
+      mapOf("gdocmdservice01_trivial.md",
+        readFile("scenarios/01_trivial/expected_md/gdocmdservice01_trivial.md")),
+      convert(
+        mapOf("gdocmdservice01_trivial.html",
+          readFile("scenarios/01_trivial/actual_gdoc/gdocmdservice01_trivial.html"))
+      ));
+  }
+}

--- a/convert/javatest/gdocmd/convert/TestUtil.java
+++ b/convert/javatest/gdocmd/convert/TestUtil.java
@@ -1,0 +1,84 @@
+package gdocmd.convert;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class TestUtil {
+  public static <K, V> Map<K, V> emptyMap() {
+    return Collections.unmodifiableMap(new HashMap<>());
+  }
+
+  public static <K, V> Map<K, V> mapOf(
+    K k1, V v1) {
+    Map<K, V> m = new LinkedHashMap<>();
+    m.put(k1, v1);
+    return Collections.unmodifiableMap(m);
+  }
+
+  public static <K, V> Map<K, V> mapOf(
+    K k1, V v1,
+    K k2, V v2) {
+    Map<K, V> m = new LinkedHashMap<>();
+    m.put(k1, v1);
+    m.put(k2, v2);
+    return Collections.unmodifiableMap(m);
+  }
+
+  public static <K, V> Map<K, V> mapOf(
+    K k1, V v1,
+    K k2, V v2,
+    K k3, V v3) {
+    Map<K, V> m = new LinkedHashMap<>();
+    m.put(k1, v1);
+    m.put(k2, v2);
+    m.put(k3, v3);
+    return Collections.unmodifiableMap(m);
+  }
+
+  public static <K, V> Map<K, V> mapOf(
+    K k1, V v1,
+    K k2, V v2,
+    K k3, V v3,
+    K k4, V v4) {
+    Map<K, V> m = new LinkedHashMap<>();
+    m.put(k1, v1);
+    m.put(k2, v2);
+    m.put(k3, v3);
+    m.put(k4, v4);
+    return Collections.unmodifiableMap(m);
+  }
+
+  public static <K, V> Map<K, V> mapOf(
+    K k1, V v1,
+    K k2, V v2,
+    K k3, V v3,
+    K k4, V v4,
+    K k5, V v5) {
+    Map<K, V> m = new LinkedHashMap<>();
+    m.put(k1, v1);
+    m.put(k2, v2);
+    m.put(k3, v3);
+    m.put(k4, v4);
+    m.put(k5, v5);
+    return Collections.unmodifiableMap(m);
+  }
+
+  public static <K, V> Map<K, V> mapOf(
+    K k1, V v1,
+    K k2, V v2,
+    K k3, V v3,
+    K k4, V v4,
+    K k5, V v5,
+    K k6, V v6) {
+    Map<K, V> m = new LinkedHashMap<>();
+    m.put(k1, v1);
+    m.put(k2, v2);
+    m.put(k3, v3);
+    m.put(k4, v4);
+    m.put(k5, v5);
+    m.put(k6, v6);
+    return Collections.unmodifiableMap(m);
+  }
+}

--- a/convert/scenarios/01_trivial/actual_gdoc/gdocmdservice01_trivial.html
+++ b/convert/scenarios/01_trivial/actual_gdoc/gdocmdservice01_trivial.html
@@ -1,0 +1,172 @@
+<html>
+
+<head>
+  <meta content="text/html; charset=UTF-8" http-equiv="content-type">
+  <style type="text/css">
+    ol {
+      margin: 0;
+      padding: 0
+    }
+
+    table td,
+    table th {
+      padding: 0
+    }
+
+    .c2 {
+      color: #000000;
+      font-weight: 400;
+      text-decoration: none;
+      vertical-align: baseline;
+      font-size: 11pt;
+      font-family: "Arial";
+      font-style: normal
+    }
+
+    .c1 {
+      padding-top: 0pt;
+      padding-bottom: 0pt;
+      line-height: 1.15;
+      orphans: 2;
+      widows: 2;
+      text-align: left
+    }
+
+    .c0 {
+      background-color: #ffffff;
+      max-width: 468pt;
+      padding: 72pt 72pt 72pt 72pt
+    }
+
+    .title {
+      padding-top: 0pt;
+      color: #000000;
+      font-weight: 700;
+      font-size: 24pt;
+      padding-bottom: 0pt;
+      font-family: "Arial";
+      line-height: 1.15;
+      page-break-after: avoid;
+      orphans: 2;
+      widows: 2;
+      text-align: left
+    }
+
+    .subtitle {
+      padding-top: 0pt;
+      color: #666666;
+      font-size: 13pt;
+      padding-bottom: 10pt;
+      font-family: "Trebuchet MS";
+      line-height: 1.15;
+      page-break-after: avoid;
+      font-style: italic;
+      orphans: 2;
+      widows: 2;
+      text-align: left
+    }
+
+    li {
+      color: #000000;
+      font-size: 11pt;
+      font-family: "Arial"
+    }
+
+    p {
+      margin: 0;
+      color: #000000;
+      font-size: 11pt;
+      font-family: "Arial"
+    }
+
+    h1 {
+      padding-top: 10pt;
+      color: #000000;
+      font-weight: 700;
+      font-size: 20pt;
+      padding-bottom: 0pt;
+      font-family: "Arial";
+      line-height: 1.15;
+      page-break-after: avoid;
+      orphans: 2;
+      widows: 2;
+      text-align: left
+    }
+
+    h2 {
+      padding-top: 0pt;
+      color: #000000;
+      font-weight: 700;
+      font-size: 14pt;
+      padding-bottom: 0pt;
+      font-family: "Arial";
+      line-height: 1.15;
+      orphans: 2;
+      widows: 2;
+      text-align: left
+    }
+
+    h3 {
+      padding-top: 8pt;
+      color: #666666;
+      font-weight: 700;
+      font-size: 12pt;
+      padding-bottom: 0pt;
+      font-family: "Arial";
+      line-height: 1.15;
+      page-break-after: avoid;
+      orphans: 2;
+      widows: 2;
+      text-align: left
+    }
+
+    h4 {
+      padding-top: 8pt;
+      color: #666666;
+      text-decoration: underline;
+      font-size: 11pt;
+      padding-bottom: 0pt;
+      font-family: "Trebuchet MS";
+      line-height: 1.15;
+      page-break-after: avoid;
+      orphans: 2;
+      widows: 2;
+      text-align: left
+    }
+
+    h5 {
+      padding-top: 8pt;
+      color: #666666;
+      font-size: 11pt;
+      padding-bottom: 0pt;
+      font-family: "Trebuchet MS";
+      line-height: 1.15;
+      page-break-after: avoid;
+      orphans: 2;
+      widows: 2;
+      text-align: left
+    }
+
+    h6 {
+      padding-top: 8pt;
+      color: #666666;
+      font-size: 11pt;
+      padding-bottom: 0pt;
+      font-family: "Trebuchet MS";
+      line-height: 1.15;
+      page-break-after: avoid;
+      font-style: italic;
+      orphans: 2;
+      widows: 2;
+      text-align: left
+    }
+  </style>
+</head>
+
+<body class="c0">
+  <p class="c1">
+    <span class="c2">Hello World</span>
+  </p>
+</body>
+
+</html>

--- a/convert/scenarios/01_trivial/expected_md/gdocmdservice01_trivial.md
+++ b/convert/scenarios/01_trivial/expected_md/gdocmdservice01_trivial.md
@@ -1,0 +1,1 @@
+Hello World

--- a/service/BUILD
+++ b/service/BUILD
@@ -1,9 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 load("@io_bazel_rules_appengine//appengine:appengine.bzl", "appengine_war")
 load("@rules_intellij_generate//:def.bzl",
-    "intellij_source_java_library",
-    "MAVEN_STANDARD_JAVA_SOURCE_FOLDER_MAP",
-    "MAVEN_STANDARD_JAVA_TEST_FOLDER_MAP")
+    "intellij_source_java_library")
 
 appengine_war(
     name = "backend",
@@ -19,7 +17,7 @@ filegroup(
 
 intellij_source_java_library(
     name="lib",
-    source_folder_to_wildcard_map=MAVEN_STANDARD_JAVA_SOURCE_FOLDER_MAP,
+    source_folder_to_wildcard_map={"javasrc":"**/*.java"},
     deps=[
         "@javax_servlet_api//jar",
         "@com_google_appengine_java//:api",
@@ -32,12 +30,8 @@ intellij_source_java_library(
 # run directly, only used as a library).
 java_binary(
     name = "app",
-    # srcs = glob(["src/main/java/**/*.java"]),
     main_class = "does.not.exist",
-    runtime_deps = [
-        ":lib"
-        # "@io_bazel_rules_appengine//appengine:javax.servlet.api",
-    ],
+    runtime_deps = [":lib"],
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_iml")

--- a/service/javasrc/gdocmd/service/MyAppServlet.java
+++ b/service/javasrc/gdocmd/service/MyAppServlet.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.bazel.example.app;
+package gdocmd.service;
 
 import java.io.IOException;
 

--- a/service/javasrc/gdocmd/service/MyCronServlet.java
+++ b/service/javasrc/gdocmd/service/MyCronServlet.java
@@ -1,4 +1,4 @@
-package com.google.bazel.example.app;
+package gdocmd.service;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;

--- a/service/webapp/WEB-INF/web.xml
+++ b/service/webapp/WEB-INF/web.xml
@@ -4,7 +4,7 @@
 <web-app xmlns="http://java.sun.com/xml/ns/javaee" version="2.5">
   <servlet>
     <servlet-name>my-app</servlet-name>
-    <servlet-class>com.google.bazel.example.app.MyAppServlet</servlet-class>
+    <servlet-class>gdocmd.service.MyAppServlet</servlet-class>
   </servlet>
   <servlet-mapping>
     <servlet-name>my-app</servlet-name>
@@ -13,7 +13,7 @@
 
   <servlet>
     <servlet-name>my-cron</servlet-name>
-    <servlet-class>com.google.bazel.example.app.MyCronServlet</servlet-class>
+    <servlet-class>gdocmd.service.MyCronServlet</servlet-class>
   </servlet>
   <servlet-mapping>
     <servlet-name>my-cron</servlet-name>


### PR DESCRIPTION
advance intellij rules
transform module. javasrc/javatest organization.
complete the package reorg
first convert test, but cheating, just to get stuff in place
transform -> convert
actually parse the gdoc html